### PR TITLE
./build.sh: `docker cp` behaviour changed slightly in docker 1.8

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -15,6 +15,7 @@ cleanup() {
     docker rm -v ${DIST_CONTAINER}
 }
 trap cleanup EXIT
-docker cp ${DIST_CONTAINER}:/source/dist/artifacts dist
+mkdir -p dist
+docker cp ${DIST_CONTAINER}:/source/dist/artifacts dist/
 
 ls -l dist/artifacts


### PR DESCRIPTION
./build.sh: `docker cp` behaviour changed slightly in docker 1.8
