### PR TITLE
Revert "Fix: `make oldconfig` asks if we need kexec-zlib after adding kexec"

### DIFF
--- a/config/amd64/buildroot-config
+++ b/config/amd64/buildroot-config
@@ -402,7 +402,6 @@ BR2_PACKAGE_GOOGLE_BREAKPAD_ARCH_SUPPORTS=y
 #
 # BR2_PACKAGE_IOZONE is not set
 BR2_PACKAGE_KEXEC=y
-# BR2_PACKAGE_KEXEC_ZLIB is not set
 
 #
 # ktap needs a Linux kernel to be built

--- a/config/arm/buildroot-config
+++ b/config/arm/buildroot-config
@@ -422,7 +422,6 @@ BR2_PACKAGE_GOOGLE_BREAKPAD_ARCH_SUPPORTS=y
 #
 # BR2_PACKAGE_IOZONE is not set
 BR2_PACKAGE_KEXEC=y
-# BR2_PACKAGE_KEXEC_ZLIB is not set
 
 #
 # ktap needs a Linux kernel to be built


### PR DESCRIPTION
Reverts rancher/os-base#26
