### PR TITLE
Add cryptsetup package

### DIFF
--- a/config/amd64/buildroot-config
+++ b/config/amd64/buildroot-config
@@ -856,6 +856,7 @@ BR2_PACKAGE_ACPID=y
 # BR2_PACKAGE_CDRKIT is not set
 # BR2_PACKAGE_CWIID is not set
 BR2_PACKAGE_CRYPTSETUP=y
+
 #
 # dahdi-linux needs a Linux kernel to be built
 #

--- a/config/amd64/buildroot-config
+++ b/config/amd64/buildroot-config
@@ -854,7 +854,6 @@ BR2_PACKAGE_ACPID=y
 # cc-tool needs a toolchain w/ C++, threads, wchar
 #
 # BR2_PACKAGE_CDRKIT is not set
-# BR2_PACKAGE_CRYPTSETUP is not set
 # BR2_PACKAGE_CWIID is not set
 BR2_PACKAGE_CRYPTSETUP=y
 #

--- a/config/amd64/buildroot-config
+++ b/config/amd64/buildroot-config
@@ -856,7 +856,7 @@ BR2_PACKAGE_ACPID=y
 # BR2_PACKAGE_CDRKIT is not set
 # BR2_PACKAGE_CRYPTSETUP is not set
 # BR2_PACKAGE_CWIID is not set
-
+BR2_PACKAGE_CRYPTSETUP=y
 #
 # dahdi-linux needs a Linux kernel to be built
 #

--- a/config/arm64/buildroot-config
+++ b/config/arm64/buildroot-config
@@ -837,8 +837,8 @@ BR2_PACKAGE_QT5_JSCORE_AVAILABLE=y
 # cc-tool needs a toolchain w/ C++, threads, wchar
 #
 # BR2_PACKAGE_CDRKIT is not set
-# BR2_PACKAGE_CRYPTSETUP is not set
 # BR2_PACKAGE_CWIID is not set
+BR2_PACKAGE_CRYPTSETUP=y
 
 #
 # dahdi-linux needs a Linux kernel to be built


### PR DESCRIPTION
## What does this do

Makes cryptsetup available in the default console and during boot. Allowing for LUKS encrypted devices. 

## How was this tested

Followed build instructions to build RancherOS for AMD64. Booted ISO using docker-machine and add second harddrive. Encrypted second harddrive using the following procedure:
```
[root@rancher-test ~]# cryptsetup -y -v luksFormat --force-password /dev/sdb

WARNING!
========
This will overwrite data on /dev/sdb irrevocably.

Are you sure? (Type uppercase yes): YES
Enter passphrase for /dev/sdb:
Verify passphrase:
Command successful.
[root@rancher-test ~]# cryptsetup luksOpen /dev/sdb luks-sdb
Enter passphrase for /dev/sdb:
[root@rancher-test docker]# ls /dev/mapper/
control    luks-sdb

[root@rancher-test docker]# uname -a
Linux rancher-test 4.14.73-rancher #1 SMP Thu Oct 4 00:19:21 UTC 2018 x86_64 GNU/Linux
```